### PR TITLE
docs: Add initial governance.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,6 @@
+### CITGM Code of Conduct
+
+The [Node.js Code of Conduct][] applies to this repo.
+
+[node.js code of conduct]:
+  https://github.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Making changes to the Website-Prototype
+
+## Collaboration Policy
+
+- All changes must come in a PR
+- All changes must be reviewed by another Collaborator or member of
+  @nodejs/website or @nodejs/website-redesign
+
+## Commit Guidelines
+
+There is a built in commit linter. Basic rules:
+
+* Commit messages must start with a capitol letter
+* Commit message must end with a period `.`
+* Supported subsystems:
+
+build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test

--- a/ModerationPolicy.md
+++ b/ModerationPolicy.md
@@ -1,0 +1,6 @@
+### CITGM Moderation Policy
+
+The [Node.js Moderation Policy][] applies to this repo.
+
+[node.js moderation policy]:
+  https://github.com/nodejs/admin/blob/master/Moderation-Policy.md


### PR DESCRIPTION
References foundation default CoC and Moderation policy.

CONTRIBUTING.md outlines basic governance for landing code changes.

TL;DR

* all changes require a PR and review from one other individual
* anyone from @nodejs/website or @nodejs/website-redesign can approve