### PR TITLE
fix(branding): Use 'Node.js' instead of 'Node'.

### DIFF
--- a/src/documentation/0001-node-introduction/index.md
+++ b/src/documentation/0001-node-introduction/index.md
@@ -63,7 +63,7 @@ Such mechanism derives from the browser. We can't wait until something loads fro
 
 This allows Node.js to handle thousands of concurrent connections with a single server without introducing the burden of managing threads concurrency, which would be a major source of bugs.
 
-Node provides non-blocking I/O primitives, and generally, libraries in Node.js are written using non-blocking paradigms, making a blocking behavior an exception rather than the normal.
+Node.js provides non-blocking I/O primitives, and generally, libraries in Node.js are written using non-blocking paradigms, making a blocking behavior an exception rather than the normal.
 
 When Node.js needs to perform an I/O operation, like reading from the network, access a database or the filesystem, instead of blocking the thread Node.js will simply resume the operations when the response comes back, instead of wasting CPU cycles waiting.
 

--- a/src/documentation/0002-node-history/index.md
+++ b/src/documentation/0002-node-history/index.md
@@ -10,9 +10,9 @@ In comparison, JavaScript is 23 years old and the web as we know it (after the i
 
 9 years is such a little amount of time for a technology, but Node.js seems to have been around forever.
 
-I've had the pleasure to work with Node since the early days when it was just 2 years old, and despite the little information available, you could already feel it was a huge thing.
+I've had the pleasure to work with Node.js since the early days when it was just 2 years old, and despite the little information available, you could already feel it was a huge thing.
 
-In this post, we want to draw the big picture of Node in its history, to put things in perspective.
+In this post, we want to draw the big picture of Node.js in its history, to put things in perspective.
 
 <!-- TOC -->
 
@@ -55,7 +55,7 @@ Express is born
 ## 2011
 
 npm hits 1.0
-Big companies start adopting Node: LinkedIn, Uber
+Big companies start adopting Node.js: LinkedIn, Uber
 [Hapi](https://hapijs.com) is born
 
 ## 2012
@@ -64,7 +64,7 @@ Adoption continues very rapidly
 
 ## 2013
 
-First big blogging platform using Node: Ghost
+First big blogging platform using Node.js: Ghost
 [Koa](https://koajs.com/) is born
 
 ## 2014
@@ -76,23 +76,23 @@ The Big Fork: [io.js](https://iojs.org/) is a major fork of Node.js, with the go
 The [Node.js Foundation](https://foundation.nodejs.org/) is born
 IO.js is merged back into Node.js
 npm introduces private modules
-Node 4 (no 1, 2, 3 versions were previously released)
+Node.js 4 (no 1, 2, 3 versions were previously released)
 
 ## 2016
 
 The [leftpad incident](https://blog.npmjs.org/post/141577284765/kik-left-pad-and-npm)
 Yarn is born
-Node 6
+Node.js 6
 
 ## 2017
 
 npm focuses more on security
-Node 8
+Node.js 8
 HTTP/2
-V8 introduces Node in its testing suite, officially making Node a target for the JS engine, in addition to Chrome
+V8 introduces Node.js in its testing suite, officially making Node.js a target for the JS engine, in addition to Chrome
 3 billion npm downloads every week
 
 ## 2018
 
-Node 10
+Node.js 10
 ES modules .mjs experimental support

--- a/src/documentation/0003-node-installation/index.md
+++ b/src/documentation/0003-node-installation/index.md
@@ -18,12 +18,12 @@ brew install node
 
 Other package managers for Linux and Windows are listed in <https://nodejs.org/en/download/package-manager/>
 
-`nvm` is a popular way to run Node. It allows you to easily switch the Node version, and install new versions to try and easily rollback if something breaks, for example.
+`nvm` is a popular way to run Node. It allows you to easily switch the Node.js version, and install new versions to try and easily rollback if something breaks, for example.
 
-It is also very useful to test your code with old Node versions.
+It is also very useful to test your code with old Node.js versions.
 
 See <https://github.com/creationix/nvm> for more information about this option.
 
 My suggestion is to use the official installer if you are just starting out and you don't use Homebrew already, otherwise, Homebrew is my favorite solution.
 
-In any case, when Node is installed you'll have access to the `node` executable program in the command line.
+In any case, when Node.js is installed you'll have access to the `node` executable program in the command line.

--- a/src/documentation/0004-node-javascript-language/index.md
+++ b/src/documentation/0004-node-javascript-language/index.md
@@ -1,5 +1,5 @@
 ---
-title: How much JavaScript do you need to know to use Node?
+title: How much JavaScript do you need to know to use Node.js?
 description: 'If you are just starting out with JavaScript, how much deeply do you need to know the language?'
 author: flaviocopes
 ---

--- a/src/documentation/0005-node-difference-browser/index.md
+++ b/src/documentation/0005-node-difference-browser/index.md
@@ -1,33 +1,33 @@
 ---
-title: Differences between Node and the Browser
+title: Differences between Node.js and the Browser
 description: 'How writing JavaScript application in Node.js differs from programming for the Web inside the browser'
 author: flaviocopes
 ---
 
-Both the browser and Node use JavaScript as their programming language.
+Both the browser and Node.js use JavaScript as their programming language.
 
 Building apps that run in the browser is a completely different thing than building a Node.js application.
 
 Despite the fact that it's always JavaScript, there are some key differences that make the experience radically different.
 
-As a frontend developer who extensively uses Javascript, Node apps brings with it, a huge advantage - the comfort of programming everything, the frontend and the backend, in a single language
+As a frontend developer who extensively uses Javascript, Node.js apps brings with it, a huge advantage - the comfort of programming everything, the frontend and the backend, in a single language
 
 You have a huge opportunity because we know how hard it is to fully, deeply learn a programming language, and by using the same language to perform all your work on the web - both on the client and on the server, you're in a unique position of advantage.
 
 What changes is the ecosystem.
 
-In the browser, most of the time what you are doing is interacting with the DOM, or other Web Platform APIs like Cookies. Those do not exist in Node, of course. You don't have the `document`, `window` and all the other objects that are provided by the browser.
+In the browser, most of the time what you are doing is interacting with the DOM, or other Web Platform APIs like Cookies. Those do not exist in Node.js, of course. You don't have the `document`, `window` and all the other objects that are provided by the browser.
 
 And in the browser, we don't have all the nice APIs that Node.js provides through its modules, like the filesystem access functionality.
 
-Another big difference is that in Node.js you control the environment. Unless you are building an open source application that anyone can deploy anywhere, you know which version of Node you will run the application on. Compared to the browser environment, where you don't get the luxury to choose what browser your visitors will use, this is very convenient.
+Another big difference is that in Node.js you control the environment. Unless you are building an open source application that anyone can deploy anywhere, you know which version of Node.js you will run the application on. Compared to the browser environment, where you don't get the luxury to choose what browser your visitors will use, this is very convenient.
 
-This means that you can write all the modern ES6-7-8-9 JavaScript that your Node version supports.
+This means that you can write all the modern ES6-7-8-9 JavaScript that your Node.js version supports.
 
 Since JavaScript moves so fast, but browsers can be a bit slow and users a bit slow to upgrade, sometimes on the web, you are stuck to use older JavaScript / ECMAScript releases.
 
-You can use Babel to transform your code to be ES5-compatible before shipping it to the browser, but in Node, you won't need that.
+You can use Babel to transform your code to be ES5-compatible before shipping it to the browser, but in Node.js, you won't need that.
 
-Another difference is that Node uses the CommonJS module system, while in the browser we are starting to see the ES Modules standard being implemented.
+Another difference is that Node.js uses the CommonJS module system, while in the browser we are starting to see the ES Modules standard being implemented.
 
-In practice, this means that for the time being you use `require()` in Node and `import` in the browser.
+In practice, this means that for the time being you use `require()` in Node.js and `import` in the browser.

--- a/src/documentation/0007-node-run-cli/index.md
+++ b/src/documentation/0007-node-run-cli/index.md
@@ -4,9 +4,9 @@ description: 'How to run any Node.js script from the CLI'
 author: flaviocopes
 ---
 
-The usual way to run a Node program is to call the `node` globally available command (once you install Node) and pass the name of the file you want to execute.
+The usual way to run a Node.js program is to call the `node` globally available command (once you install Node.js) and pass the name of the file you want to execute.
 
-If your main Node application file is in `app.js`, you can call it by typing
+If your main Node.js application file is in `app.js`, you can call it by typing
 
 ```sh
 node app.js

--- a/src/documentation/0008-node-terminate-program/index.md
+++ b/src/documentation/0008-node-terminate-program/index.md
@@ -32,11 +32,11 @@ You can also set the `process.exitCode` property:
 process.exitCode = 1
 ```
 
-and when the program will later end, Node will return that exit code.
+and when the program will later end, Node.js will return that exit code.
 
 A program will gracefully exit when all the processing is done.
 
-Many times with Node we start servers, like this HTTP server:
+Many times with Node.js we start servers, like this HTTP server:
 
 ```js
 const express = require('express')

--- a/src/documentation/0009-node-environment-variables/index.md
+++ b/src/documentation/0009-node-environment-variables/index.md
@@ -4,7 +4,7 @@ description: 'Learn how to read and make use of environment variables in a Node.
 author: flaviocopes
 ---
 
-The `process` core module of Node provides the `env` property which hosts all the environment variables that were set at the moment the process was started.
+The `process` core module of Node.js provides the `env` property which hosts all the environment variables that were set at the moment the process was started.
 
 Here is an example that accesses the NODE_ENV environment variable, which is set to `development` by default.
 
@@ -14,6 +14,6 @@ Here is an example that accesses the NODE_ENV environment variable, which is set
 process.env.NODE_ENV // "development"
 ```
 
-Setting it to "production" before the script runs will tell Node that this is a production environment.
+Setting it to "production" before the script runs will tell Node.js that this is a production environment.
 
 In the same way you can access any custom environment variable you set.

--- a/src/documentation/0011-node-repl/index.md
+++ b/src/documentation/0011-node-repl/index.md
@@ -1,6 +1,6 @@
 ---
 title: How to use the Node.js REPL
-description: "REPL stands for Read-Evaluate-Print-Loop, and it's a great way to explore the Node features in a quick way"
+description: "REPL stands for Read-Evaluate-Print-Loop, and it's a great way to explore the Node.js features in a quick way"
 author: flaviocopes
 ---
 

--- a/src/documentation/0012-node-cli-args/index.md
+++ b/src/documentation/0012-node-cli-args/index.md
@@ -1,5 +1,5 @@
 ---
-title: Node, accept arguments from the command line
+title: Node.js, accept arguments from the command line
 description: 'How to accept arguments in a Node.js program passed from the command line'
 author: flaviocopes
 ---
@@ -24,7 +24,7 @@ or
 node app.js name=joe
 ```
 
-This changes how you will retrieve this value in the Node code.
+This changes how you will retrieve this value in the Node.js code.
 
 The way you retrieve it is using the `process` object built into Node.
 

--- a/src/documentation/0013-node-output-to-cli/index.md
+++ b/src/documentation/0013-node-output-to-cli/index.md
@@ -1,6 +1,6 @@
 ---
-title: Output to the command line using Node
-description: 'How to print to the command line console using Node, from the basic console.log to more complex scenarios'
+title: Output to the command line using Node.js
+description: 'How to print to the command line console using Node.js, from the basic console.log to more complex scenarios'
 author: flaviocopes
 ---
 
@@ -19,7 +19,7 @@ author: flaviocopes
 
 ## Basic output using the console module
 
-Node provides a [`console` module](https://nodejs.org/api/console.html) which provides tons of very useful ways to interact with the command line.
+Node.js provides a [`console` module](https://nodejs.org/api/console.html) which provides tons of very useful ways to interact with the command line.
 
 It is basically the same as the `console` object you find in the browser.
 
@@ -35,7 +35,7 @@ const y = 'y'
 console.log(x, y)
 ```
 
-and Node will print both.
+and Node.js will print both.
 
 We can also format pretty phrases by passing variables and a format specifier.
 
@@ -108,7 +108,7 @@ const function1 = () => function2()
 function1()
 ```
 
-This will print the stack trace. This is what's printed if we try this in the Node REPL:
+This will print the stack trace. This is what's printed if we try this in the Node.js REPL:
 
 ```txt
 Trace
@@ -157,7 +157,7 @@ Example:
 console.log('\x1b[33m%s\x1b[0m', 'hi!')
 ```
 
-You can try that in the Node REPL, and it will print `hi!` in yellow.
+You can try that in the Node.js REPL, and it will print `hi!` in yellow.
 
 However, this is the low-level way to do this. The simplest way to go about coloring the console output is by using a library. [Chalk](https://github.com/chalk/chalk) is such a library, and in addition to coloring it also helps with other styling facilities, like making text bold, italic or underlined.
 

--- a/src/documentation/0014-node-input-from-cli/index.md
+++ b/src/documentation/0014-node-input-from-cli/index.md
@@ -1,12 +1,12 @@
 ---
-title: Accept input from the command line in Node
-description: 'How to make a Node.js CLI program interactive using the built-in readline Node module'
+title: Accept input from the command line in Node.js
+description: 'How to make a Node.js CLI program interactive using the built-in readline Node.js module'
 author: flaviocopes
 ---
 
 How to make a Node.js CLI program interactive?
 
-Node since version 7 provides the [`readline` module](https://nodejs.org/api/readline.html) to perform exactly this: get input from a readable stream such as the `process.stdin` stream, which during the execution of a Node program is the terminal input, one line at a time.
+Node.js since version 7 provides the [`readline` module](https://nodejs.org/api/readline.html) to perform exactly this: get input from a readable stream such as the `process.stdin` stream, which during the execution of a Node.js program is the terminal input, one line at a time.
 
 ```js
 const readline = require('readline').createInterface({
@@ -54,4 +54,4 @@ inquirer.prompt(questions).then(answers => {
 
 Inquirer.js lets you do many things like asking multiple choices, having radio buttons, confirmations, and more.
 
-It's worth knowing all the alternatives, especially the built-in ones provided by Node, but if you plan to take CLI input to the next level, Inquirer.js is an optimal choice.
+It's worth knowing all the alternatives, especially the built-in ones provided by Node.js, but if you plan to take CLI input to the next level, Inquirer.js is an optimal choice.

--- a/src/documentation/0015-node-export-module/index.md
+++ b/src/documentation/0015-node-export-module/index.md
@@ -1,10 +1,10 @@
 ---
-title: Expose functionality from a Node file using exports
+title: Expose functionality from a Node.js file using exports
 description: 'How to use the module.exports API to expose data to other files in your application, or to other applications as well'
 author: flaviocopes
 ---
 
-Node has a built-in module system.
+Node.js has a built-in module system.
 
 A Node.js file can import functionality exposed by other Node.js files.
 

--- a/src/documentation/0018-how-to-use-npm-package/index.md
+++ b/src/documentation/0018-how-to-use-npm-package/index.md
@@ -4,7 +4,7 @@ description: 'How to include and use in your code a package installed in your no
 author: flaviocopes
 ---
 
-When you install using `npm` a package into your `node_modules` folder, or also globally, how do you use it in your Node code?
+When you install using `npm` a package into your `node_modules` folder, or also globally, how do you use it in your Node.js code?
 
 Say you install `lodash`, the popular JavaScript utility library, using
 

--- a/src/documentation/0019-package-json/index.md
+++ b/src/documentation/0019-package-json/index.md
@@ -147,7 +147,7 @@ there are _lots_ of things going on here:
 - `scripts` defines a set of node scripts you can run
 - `dependencies` sets a list of `npm` packages installed as dependencies
 - `devDependencies` sets a list of `npm` packages installed as development dependencies
-- `engines` sets which versions of Node this package/app works on
+- `engines` sets which versions of Node.js this package/app works on
 - `browserslist` is used to tell which browsers (and their versions) you want to support
 
 All those properties are used by either `npm` or other tools that we can use.

--- a/src/documentation/0023-update-npm-dependencies/index.md
+++ b/src/documentation/0023-update-npm-dependencies/index.md
@@ -1,5 +1,5 @@
 ---
-title: Update all the Node dependencies to their latest version
+title: Update all the Node.js dependencies to their latest version
 description: 'How do you update all the npm dependencies store in the package.json file, to their latest version available?'
 author: flaviocopes
 ---

--- a/src/documentation/0025-npm-uninstall-packages/index.md
+++ b/src/documentation/0025-npm-uninstall-packages/index.md
@@ -1,6 +1,6 @@
 ---
 title: Uninstalling npm packages
-description: 'How to uninstall an npm Node package, locally or globally'
+description: 'How to uninstall an npm Node.js package, locally or globally'
 author: flaviocopes
 ---
 

--- a/src/documentation/0028-npx/index.md
+++ b/src/documentation/0028-npx/index.md
@@ -1,6 +1,6 @@
 ---
-title: The npx Node Package Runner
-description: 'npx is a very cool way to run Node code, and provides many useful features'
+title: The npx Node.js Package Runner
+description: 'npx is a very cool way to run Node.js code, and provides many useful features'
 author: flaviocopes
 ---
 
@@ -8,11 +8,11 @@ author: flaviocopes
 
 > If you don't want to install npm, you can [install npx as a standalone package](https://www.npmjs.com/package/npx)
 
-`npx` lets you run code built with Node and published through the npm registry.
+`npx` lets you run code built with Node.js and published through the npm registry.
 
 ## Easily run local commands
 
-Node developers used to publish most of the executable commands as global packages, in order for them to be in the path and executable immediately.
+Node.js developers used to publish most of the executable commands as global packages, in order for them to be in the path and executable immediately.
 
 This was a pain because you could not really install different versions of the same command.
 
@@ -62,7 +62,7 @@ and many more.
 
 Once downloaded, the downloaded code will be wiped.
 
-## Run some code using a different Node version
+## Run some code using a different Node.js version
 
 Use the `@` to specify the version, and combine that with the [`node` npm package](https://www.npmjs.com/package/node):
 
@@ -71,7 +71,7 @@ npx node@6 -v #v6.14.3
 npx node@8 -v #v8.11.3
 ```
 
-This helps to avoid tools like `nvm` or the other Node version management tools.
+This helps to avoid tools like `nvm` or the other Node.js version management tools.
 
 ## Run arbitrary code snippets directly from a URL
 

--- a/src/documentation/0029-node-event-loop/index.md
+++ b/src/documentation/0029-node-event-loop/index.md
@@ -1,6 +1,6 @@
 ---
 title: 'The Node.js Event Loop'
-description: 'The Event Loop is one of the most important aspects to understand about Node'
+description: 'The Event Loop is one of the most important aspects to understand about Node.js'
 author: flaviocopes
 ---
 
@@ -20,7 +20,7 @@ author: flaviocopes
 
 The **Event Loop** is one of the most important aspects to understand about Node.
 
-Why is this so important? Because it explains how Node can be asynchronous and have non-blocking I/O, and so it explains basically the "killer app" of Node, the thing that made it this successful.
+Why is this so important? Because it explains how Node.js can be asynchronous and have non-blocking I/O, and so it explains basically the "killer app" of Node.js, the thing that made it this successful.
 
 The Node.js JavaScript code runs on a single thread. There is just one thing happening at a time.
 

--- a/src/documentation/0036-node-event-emitter/index.md
+++ b/src/documentation/0036-node-event-emitter/index.md
@@ -1,12 +1,12 @@
 ---
-title: The Node Event emitter
-description: 'How to work with custom events in Node'
+title: The Node.js Event emitter
+description: 'How to work with custom events in Node.js'
 author: flaviocopes
 ---
 
 If you worked with JavaScript in the browser, you know how much of the interaction of the user is handled through events: mouse clicks, keyboard button presses, reacting to mouse movements, and so on.
 
-On the backend side, Node offers us the option to build a similar system using the [`events` module](https://nodejs.org/api/events.html).
+On the backend side, Node.js offers us the option to build a similar system using the [`events` module](https://nodejs.org/api/events.html).
 
 This module, in particular, offers the `EventEmitter` class, which we'll use to handle our events.
 

--- a/src/documentation/0038-node-make-http-requests/index.md
+++ b/src/documentation/0038-node-make-http-requests/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'Making HTTP requests with Node'
+title: 'Making HTTP requests with Node.js'
 description: 'How to perform HTTP requests with Node.js using GET, POST, PUT and DELETE'
 author: flaviocopes
 ---

--- a/src/documentation/0039-node-http-post/index.md
+++ b/src/documentation/0039-node-http-post/index.md
@@ -1,12 +1,12 @@
 ---
-title: Make an HTTP POST request using Node
-description: 'Find out how to make an HTTP POST request using Node'
+title: Make an HTTP POST request using Node.js
+description: 'Find out how to make an HTTP POST request using Node.js'
 author: flaviocopes
 ---
 
-There are many ways to perform an HTTP POST request in Node, depending on the abstraction level you want to use.
+There are many ways to perform an HTTP POST request in Node.js, depending on the abstraction level you want to use.
 
-The simplest way to perform an HTTP request using Node is to use the Axios library:
+The simplest way to perform an HTTP request using Node.js is to use the Axios library:
 
 ```js
 const axios = require('axios')
@@ -49,7 +49,7 @@ request.post(
 
 The 2 ways highlighted up to now require the use of a 3rd part library.
 
-A POST request is possible just using the Node standard modules, although it's more verbose than the two preceding options:
+A POST request is possible just using the Node.js standard modules, although it's more verbose than the two preceding options:
 
 ```js
 const https = require('https')

--- a/src/documentation/0040a-node-request-data/index.md
+++ b/src/documentation/0040a-node-request-data/index.md
@@ -1,12 +1,12 @@
 ---
-title: Get HTTP request body data using Node
-description: 'Find out how to extract the data sent as JSON through an HTTP request body using Node'
+title: Get HTTP request body data using Node.js
+description: 'Find out how to extract the data sent as JSON through an HTTP request body using Node.js'
 author: flaviocopes
 ---
 
 Here is how you can extract the data that was sent as JSON in the request body.
 
-If you are using Express, that's quite simple: use the `body-parser` Node module.
+If you are using Express, that's quite simple: use the `body-parser` Node.js module.
 
 For example, to get the body of this request:
 
@@ -36,7 +36,7 @@ app.post('/endpoint', (req, res) => {
 })
 ```
 
-If you're not using Express and you want to do this in vanilla Node, you need to do a bit more work, of course, as Express abstracts a lot of this for you.
+If you're not using Express and you want to do this in vanilla Node.js, you need to do a bit more work, of course, as Express abstracts a lot of this for you.
 
 The key thing to understand is that when you initialize the HTTP server using `http.createServer()`, the callback is called when the server got all the HTTP headers, but not the request body.
 

--- a/src/documentation/0040b-node-file-descriptors/index.md
+++ b/src/documentation/0040b-node-file-descriptors/index.md
@@ -1,6 +1,6 @@
 ---
-title: 'Working with file descriptors in Node'
-description: 'How to interact with file descriptors using Node'
+title: 'Working with file descriptors in Node.js'
+description: 'How to interact with file descriptors using Node.js'
 author: flaviocopes
 ---
 

--- a/src/documentation/0041-node-file-stats/index.md
+++ b/src/documentation/0041-node-file-stats/index.md
@@ -1,6 +1,6 @@
 ---
-title: 'Node file stats'
-description: 'How to get the details of a file using Node'
+title: 'Node.js file stats'
+description: 'How to get the details of a file using Node.js'
 author: flaviocopes
 ---
 
@@ -8,7 +8,7 @@ Every file comes with a set of details that we can inspect using Node.
 
 In particular, using the `stat()` method provided by the `fs` module.
 
-You call it passing a file path, and once Node gets the file details it will call the callback function you pass, with 2 parameters: an error message, and the file stats:
+You call it passing a file path, and once Node.js gets the file details it will call the callback function you pass, with 2 parameters: an error message, and the file stats:
 
 ```js
 const fs = require('fs')
@@ -21,7 +21,7 @@ fs.stat('/Users/joe/test.txt', (err, stats) => {
 })
 ```
 
-Node provides also a sync method, which blocks the thread until the file stats are ready:
+Node.js provides also a sync method, which blocks the thread until the file stats are ready:
 
 ```js
 const fs = require('fs')

--- a/src/documentation/0042-node-file-paths/index.md
+++ b/src/documentation/0042-node-file-paths/index.md
@@ -1,6 +1,6 @@
 ---
-title: 'Node File Paths'
-description: 'How to interact with file paths and manipulate them in Node'
+title: 'Node.js File Paths'
+description: 'How to interact with file paths and manipulate them in Node.js'
 author: flaviocopes
 ---
 
@@ -70,7 +70,7 @@ You can get the absolute path calculation of a relative path using `path.resolve
 path.resolve('joe.txt') //'/Users/joe/joe.txt' if run from my home folder
 ```
 
-In this case Node will simply append `/joe.txt` to the current working directory. If you specify a second parameter folder, `resolve` will use the first as a base for the second:
+In this case Node.js will simply append `/joe.txt` to the current working directory. If you specify a second parameter folder, `resolve` will use the first as a base for the second:
 
 ```js
 path.resolve('tmp', 'joe.txt') //'/Users/joe/tmp/joe.txt' if run from my home folder

--- a/src/documentation/0043-node-reading-files/index.md
+++ b/src/documentation/0043-node-reading-files/index.md
@@ -1,10 +1,10 @@
 ---
-title: 'Reading files with Node'
-description: 'How to read files using Node'
+title: 'Reading files with Node.js'
+description: 'How to read files using Node.js'
 author: flaviocopes
 ---
 
-The simplest way to read a file in Node is to use the `fs.readFile()` method, passing it the file path and a callback function that will be called with the file data (and the error):
+The simplest way to read a file in Node.js is to use the `fs.readFile()` method, passing it the file path and a callback function that will be called with the file data (and the error):
 
 ```js
 const fs = require('fs')

--- a/src/documentation/0044-node-writing-files/index.md
+++ b/src/documentation/0044-node-writing-files/index.md
@@ -1,6 +1,6 @@
 ---
-title: 'Writing files with Node'
-description: 'How to write files using Node'
+title: 'Writing files with Node.js'
+description: 'How to write files using Node.js'
 author: flaviocopes
 ---
 

--- a/src/documentation/0045-node-folders/index.md
+++ b/src/documentation/0045-node-folders/index.md
@@ -1,6 +1,6 @@
 ---
-title: 'Working with folders in Node'
-description: 'How to interact with folders using Node'
+title: 'Working with folders in Node.js'
+description: 'How to interact with folders using Node.js'
 author: flaviocopes
 ---
 
@@ -8,7 +8,7 @@ The Node.js `fs` core module provides many handy methods you can use to work wit
 
 ## Check if a folder exists
 
-Use `fs.access()` to check if the folder exists and Node can access it with its permissions.
+Use `fs.access()` to check if the folder exists and Node.js can access it with its permissions.
 
 ## Create a new folder
 

--- a/src/documentation/0046-node-module-fs/index.md
+++ b/src/documentation/0046-node-module-fs/index.md
@@ -1,12 +1,12 @@
 ---
-title: 'The Node fs module'
+title: 'The Node.js fs module'
 description: 'The fs module of Node.js provides useful functions to interact with the file system'
 author: flaviocopes
 ---
 
 The `fs` module provides a lot of very useful functionality to access and interact with the file system.
 
-There is no need to install it. Being part of the Node core, it can be used by simply requiring it:
+There is no need to install it. Being part of the Node.js core, it can be used by simply requiring it:
 
 ```js
 const fs = require('fs')
@@ -14,7 +14,7 @@ const fs = require('fs')
 
 Once you do so, you have access to all its methods, which include:
 
-- `fs.access()`: check if the file exists and Node can access it with its permissions
+- `fs.access()`: check if the file exists and Node.js can access it with its permissions
 - `fs.appendFile()`: append data to a file. If the file does not exist, it's created
 - `fs.chmod()`: change the permissions of a file specified by the filename passed. Related: `fs.lchmod()`, `fs.fchmod()`
 - `fs.chown()`: change the owner and group of a file specified by the filename passed. Related: `fs.fchown()`, `fs.lchown()`
@@ -52,7 +52,7 @@ For example:
 
 This makes a huge difference in your application flow.
 
-> Node 10 includes [experimental support](https://nodejs.org/api/fs.html#fs_fs_promises_api) for a promise based API
+> Node.js 10 includes [experimental support](https://nodejs.org/api/fs.html#fs_fs_promises_api) for a promise based API
 
 For example let's examine the `fs.rename()` method. The asynchronous API is used with a callback:
 

--- a/src/documentation/0047-node-module-path/index.md
+++ b/src/documentation/0047-node-module-path/index.md
@@ -1,12 +1,12 @@
 ---
-title: 'The Node path module'
+title: 'The Node.js path module'
 description: 'The path module of Node.js provides useful functions to interact with file paths'
 author: flaviocopes
 ---
 
 The `path` module provides a lot of very useful functionality to access and interact with the file system.
 
-There is no need to install it. Being part of the Node core, it can be used by simply requiring it:
+There is no need to install it. Being part of the Node.js core, it can be used by simply requiring it:
 
 ```js
 const path = require('path')

--- a/src/documentation/0048-node-module-os/index.md
+++ b/src/documentation/0048-node-module-os/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'The Node os module'
+title: 'The Node.js os module'
 description: 'The os module of Node.js provides useful functions to interact with underlying system'
 author: flaviocopes
 ---
@@ -81,7 +81,7 @@ Example:
 
 ## `os.endianness()`
 
-Return `BE` or `LE` depending if Node was compiled with [Big Endian or Little Endian](https://en.wikipedia.org/wiki/Endianness).
+Return `BE` or `LE` depending if Node.js was compiled with [Big Endian or Little Endian](https://en.wikipedia.org/wiki/Endianness).
 
 ## `os.freemem()`
 
@@ -161,7 +161,7 @@ Example:
 
 ## `os.platform()`
 
-Return the platform that Node was compiled for:
+Return the platform that Node.js was compiled for:
 
 - `darwin`
 - `freebsd`

--- a/src/documentation/0049-node-module-events/index.md
+++ b/src/documentation/0049-node-module-events/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'The Node events module'
+title: 'The Node.js events module'
 description: 'The events module of Node.js provides the EventEmitter class'
 author: flaviocopes
 ---
@@ -79,7 +79,7 @@ door.listeners('open')
 
 ## `emitter.off()`
 
-Alias for `emitter.removeListener()` added in Node 10
+Alias for `emitter.removeListener()` added in Node.js 10
 
 ## `emitter.on()`
 

--- a/src/documentation/0050-node-module-http/index.md
+++ b/src/documentation/0050-node-module-http/index.md
@@ -1,10 +1,10 @@
 ---
-title: 'The Node http module'
+title: 'The Node.js http module'
 description: 'The http module of Node.js provides useful functions and classes to build an HTTP server'
 author: flaviocopes
 ---
 
-The HTTP core module is a key module to Node networking.
+The HTTP core module is a key module to Node.js networking.
 
 <!-- TOC -->
 
@@ -150,7 +150,7 @@ This property lists all the HTTP status codes and their description:
 
 Points to the global instance of the Agent object, which is an instance of the `http.Agent` class.
 
-It's used to manage connections persistance and reuse for HTTP clients, and it's a key component of Node HTTP networking.
+It's used to manage connections persistance and reuse for HTTP clients, and it's a key component of Node.js HTTP networking.
 
 More in the `http.Agent` class description later on.
 
@@ -188,7 +188,7 @@ The HTTP module provides 5 classes:
 
 ### `http.Agent`
 
-Node creates a global instance of the `http.Agent` class to manage connections persistance and reuse for HTTP clients, a key component of Node HTTP networking.
+Node.js creates a global instance of the `http.Agent` class to manage connections persistance and reuse for HTTP clients, a key component of Node.js HTTP networking.
 
 This object makes sure that every request made to a server is queued and a single socket is reused.
 

--- a/src/documentation/0051-node-buffers/index.md
+++ b/src/documentation/0051-node-buffers/index.md
@@ -1,6 +1,6 @@
 ---
-title: Node Buffers
-description: 'Learn what Node buffers are, what they are used for, how to use them'
+title: Node.js Buffers
+description: 'Learn what Node.js buffers are, what they are used for, how to use them'
 author: flaviocopes
 ---
 
@@ -12,7 +12,7 @@ It represents a fixed-size chunk of memory (can't be resized) allocated outside 
 
 You can think of a buffer like an array of integers, which each represent a byte of data.
 
-It is implemented by the Node [Buffer class](https://nodejs.org/api/buffer.html).
+It is implemented by the Node.js [Buffer class](https://nodejs.org/api/buffer.html).
 
 ## Why do we need a buffer?
 

--- a/src/documentation/0052-nodejs-streams/index.md
+++ b/src/documentation/0052-nodejs-streams/index.md
@@ -10,7 +10,7 @@ author: flaviocopes
 - [Why streams](#why-streams)
 - [An example of a stream](#an-example-of-a-stream)
 - [pipe()](#pipe)
-- [Streams-powered Node APIs](#streams-powered-node-apis)
+- [Streams-powered Node.js APIs](#streams-powered-node-apis)
 - [Different types of streams](#different-types-of-streams)
 - [How to create a readable stream](#how-to-create-a-readable-stream)
 - [How to create a writable stream](#how-to-create-a-writable-stream)
@@ -45,7 +45,7 @@ Streams basically provide two major advantages using other data handling methods
 
 A typical example is the one of reading files from a disk.
 
-Using the Node `fs` module you can read a file, and serve it over HTTP when a new connection is established to your http server:
+Using the Node.js `fs` module you can read a file, and serve it over HTTP when a new connection is established to your http server:
 
 ```js
 const http = require('http')
@@ -99,7 +99,7 @@ src.pipe(dest1)
 dest1.pipe(dest2)
 ```
 
-## Streams-powered Node APIs
+## Streams-powered Node.js APIs
 
 Due to their advantages, many Node.js core modules provide native stream handling capabilities, most notably:
 

--- a/src/documentation/0053-node-difference-dev-prod/index.md
+++ b/src/documentation/0053-node-difference-dev-prod/index.md
@@ -1,12 +1,12 @@
 ---
-title: Node, the difference between development and production
+title: Node.js, the difference between development and production
 description: 'Learn how to set up different configurations for production and development environments'
 author: flaviocopes
 ---
 
 You can have different configurations for production and development environments.
 
-Node assumes it's always running in a development environment.
+Node.js assumes it's always running in a development environment.
 You can signal Node.js that you are running in production by setting the `NODE_ENV=production` environment variable.
 
 This is usually done by executing the command

--- a/src/documentation/0054-node-exceptions/index.md
+++ b/src/documentation/0054-node-exceptions/index.md
@@ -62,7 +62,7 @@ To solve this, you listen for the `uncaughtException` event on the `process` obj
 ```js
 process.on('uncaughtException', err => {
   console.error('There was an uncaught error', err)
-  process.exit(1) //mandatory (as per the Node docs)
+  process.exit(1) //mandatory (as per the Node.js docs)
 })
 ```
 

--- a/src/documentation/0055-node-inspect-object/index.md
+++ b/src/documentation/0055-node-inspect-object/index.md
@@ -1,5 +1,5 @@
 ---
-title: How to log an object in Node
+title: How to log an object in Node.js
 description: 'Logging objects in Node.js'
 author: flaviocopes
 ---
@@ -12,11 +12,11 @@ Once you click the arrow, the log is expanded, and you can clearly see the objec
 
 ![](console-log-browser-expanded.png)
 
-In Node, the same happens.
+In Node.js, the same happens.
 
-We don’t have such luxury when we log something to the console, because that’s going to output the object to the shell if you run the Node program manually, or to the log file. You get a string representation of the object.
+We don’t have such luxury when we log something to the console, because that’s going to output the object to the shell if you run the Node.js program manually, or to the log file. You get a string representation of the object.
 
-Now, all is fine until a certain level of nesting. After two levels of nesting, Node gives up and prints `[Object]` as a placeholder:
+Now, all is fine until a certain level of nesting. After two levels of nesting, Node.js gives up and prints `[Object]` as a placeholder:
 
 ```
 const obj = {


### PR DESCRIPTION
According to branding guidelines, always use 'Node.js'